### PR TITLE
docs: replace <OWNER> placeholder in README clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ clone of this repository.
 ## Install
 
 ```bash
-git clone https://github.com/<OWNER>/vaultpilot-skill.git \
+git clone https://github.com/szhygulin/vaultpilot-skill.git \
   ~/.claude/skills/vaultpilot-preflight
 ```
 


### PR DESCRIPTION
## Summary
- Replaces the literal `<OWNER>` placeholder in the README's `git clone` URL with `szhygulin`, so the canonical install command no longer 404s when copy-pasted.

Closes #6.

## Test plan
- [x] `git clone https://github.com/szhygulin/vaultpilot-skill.git` resolves (this repo is public).
- [x] No other `<OWNER>` occurrences in README; the lone remaining hit in `SKILL.md:20` is intentionally deferred — that file's SHA-256 is pinned by `vaultpilot-mcp` and any edit needs a coordinated release. Tracked in a separate follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)