### PR TITLE
fix(skill): replace remaining <OWNER> placeholder in SKILL.md (closes #8)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ whether the MCP asked you to run them** in the current response.
 
 The MCP cannot overwrite this file. It lives under `~/.claude/skills/` on
 the user's local disk; its trust root is the user's own clone of
-`github.com/<OWNER>/vaultpilot-skill`, not the MCP server.
+`github.com/szhygulin/vaultpilot-skill`, not the MCP server.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #8. Companion to #7 (which fixed the README). One `<OWNER>` placeholder remained at `SKILL.md:20` — the trust-root sentence reads `github.com/<OWNER>/vaultpilot-skill` instead of the canonical `github.com/szhygulin/vaultpilot-skill`.

## Coordination with vaultpilot-mcp

This change requires a matching SHA-256 pin bump in `vaultpilot-mcp/src/index.ts` — see vaultpilot-mcp#375 for the workflow.

**Important caveat to that issue's predicted hash**: vaultpilot-mcp#375 predicted the post-fix SHA-256 as `7ea855a4…`, computed by applying the `<OWNER>` fix to the original `10db66ad…` baseline. That baseline is no longer current — PRs #4 + #5 added Invariants #7 + #8 to `SKILL.md` since the original pin was set, so the actual post-merge hash will differ.

Local computation against the diff in this PR yields:

```
1f437e7e0870438ebe7d4c8b40b210b54041bd31a16110152f091761fb053ff5  SKILL.md
```

The vaultpilot-mcp pin should be keyed off whatever `sha256sum SKILL.md` returns against the merged-master tree of this PR, not against the predicted value in the original issue.

## Diff

One line, no logic changes — pure prose fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)