### PR TITLE
fix(#10): Step 0 — make integrity self-check mandatory + halt on hash divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ disabled the defense; v0.4.0 makes the defense survive that omission.
 
 - **Bumps integrity sentinel to**
   `VAULTPILOT_PREFLIGHT_INTEGRITY_v5_9c4a2e7f3d816b50`.
+- **Adds Step 0 — Integrity self-check (MANDATORY, runs FIRST).**
+  Closes [#10](https://github.com/szhygulin/vaultpilot-skill/issues/10).
+  The previous `0.1.x`–`0.3.x` skills relied on the MCP-emitted
+  `PREFLIGHT SKILL INTEGRITY PIN` block to instruct the agent to run
+  `sha256sum` and compare against the pin — but the skill itself had no
+  prose making this mandatory. Result: when the local `SKILL.md` had
+  drifted from the MCP-pinned hash, multiple signing flows ran with no
+  alarm surfaced. v0.4.0 adds an explicit Step 0 in this file (placed
+  *before* the numbered invariants) that requires the agent to (a)
+  extract `Expected SHA-256` and the assembled `A+B+C` sentinel from
+  the MCP's pin block, (b) compute `sha256sum
+  ~/.claude/skills/vaultpilot-preflight/SKILL.md` locally and compare,
+  (c) confirm the sentinel is present in the skill content the `Skill`
+  tool returned. Any mismatch — or any inability to complete the check
+  (file missing, hash tool unavailable, MCP omitted the pin block) —
+  halts the signing flow with `✗ vaultpilot-preflight skill integrity
+  check FAILED — DO NOT SIGN.` and surfaces both hashes side-by-side.
+  Re-runs on every signing-related call rather than caching, so mid-
+  session tamper is caught.
 - **Tightens Invariant #2 (hash recompute)** with an explicit `chainId`-
   field assertion in the EIP-1559 RLP. The hash recompute alone does not
   catch a chainId swap (the agent recomputes from the same tampered

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,124 @@ the user's local disk; its trust root is the user's own clone of
 
 ---
 
+## Step 0 — Integrity self-check (MANDATORY, runs FIRST on every signing flow)
+
+Before running ANY of the numbered invariants below, the agent MUST
+verify this skill's own integrity against the MCP's `PREFLIGHT SKILL
+INTEGRITY PIN` block. **This step is not advisory, not optional, and
+not skippable.** Silent skipping is indistinguishable from a real
+tamper — which is precisely the attack the integrity pin exists to
+catch. A passing Step 0 is the *precondition* for trusting any other
+invariant in this file; if Step 0 fails or cannot be completed, halt
+before forwarding the prepare receipt to the user, before any
+on-device prompt fires, before any signing happens.
+
+The check has three parts. ALL three must pass before proceeding to
+Invariant #1.
+
+### Part 1 — Confirm the MCP emitted the pin block
+
+`vaultpilot-mcp` emits a `PREFLIGHT SKILL INTEGRITY PIN` block in the
+server-level `instructions` field. From it, extract:
+
+- `Expected SHA-256` — a 64-hex-char value on a line by itself.
+- The assembled sentinel = `<fragment A> + <fragment B> + <fragment C>`,
+  where the MCP lists the three fragments separately so a naïve scan
+  of the MCP's prose can't spoof a full match. Concatenate the three
+  exactly (no separators, no whitespace) into a single string.
+
+If the `PREFLIGHT SKILL INTEGRITY PIN` block is **missing** from the
+MCP's instructions, or `Expected SHA-256` is missing / blank /
+non-hex / wrong length, HALT. Lead your reply with:
+
+`✗ MCP PIN BLOCK MISSING — DO NOT SIGN.`
+
+Tell the user verbatim:
+
+> The MCP did not emit a usable `PREFLIGHT SKILL INTEGRITY PIN`
+> block. This may indicate the server is out of date,
+> misconfigured, or compromised. Without the pinned hash I cannot
+> verify this skill's integrity — and I will not sign without
+> verifying.
+
+### Part 2 — Recompute the local hash and compare
+
+Run, locally:
+
+```
+sha256sum ~/.claude/skills/vaultpilot-preflight/SKILL.md
+```
+
+(Windows: `Get-FileHash -Algorithm SHA256 …`. macOS without coreutils:
+`shasum -a 256 …` or `openssl dgst -sha256 …`.)
+
+Compare the FIRST 64 HEX CHARS of stdout — case-insensitive — to
+`Expected SHA-256` from Part 1. If they differ — even by one
+character — HALT. Lead your reply with:
+
+`✗ vaultpilot-preflight skill integrity check FAILED — DO NOT SIGN.`
+
+Surface BOTH hashes side-by-side, formatted with bold + inline-code
+markup so the user can visually diff them:
+
+```
+Local SKILL.md SHA-256 : **`<local-hash>`**
+MCP-pinned SHA-256     : **`<expected-hash>`**
+```
+
+Then tell the user verbatim:
+
+> The vaultpilot-preflight skill on your local disk does not match
+> the version this MCP expects. Possible causes: (a) the skill is
+> stale — refresh with `cd ~/.claude/skills/vaultpilot-preflight &&
+> git pull --ff-only`; (b) the MCP is stale — `npm update -g
+> vaultpilot-mcp` or matching install path; (c) one side has been
+> tampered with. Until both align, I will not sign any transaction.
+> Do not bypass this alarm; it is the canonical integrity-pin
+> mismatch that the pin exists to catch.
+
+### Part 3 — Verify the sentinel is in the skill content
+
+Confirm that the assembled sentinel string from Part 1 appears in
+**the content the `Skill` tool returned for `vaultpilot-preflight`**
+— NOT in the MCP's own instructions text. (The MCP's instructions
+list the fragments separately, so a search for the assembled string
+in the MCP prose finds nothing; finding the assembled string in the
+skill content proves you actually loaded THIS skill, not a different
+one collisively registered under the same name.)
+
+If the assembled sentinel is **absent** from the skill content, HALT
+with the same lead:
+
+`✗ vaultpilot-preflight skill integrity check FAILED — DO NOT SIGN.`
+
+Tell the user this is the plugin-collision case: another skill is
+registered under the name `vaultpilot-preflight` whose content lacks
+the v5 sentinel, and proceeding would mean trusting unknown content
+in place of this file.
+
+### Failure-mode handling
+
+- **Cannot read `~/.claude/skills/vaultpilot-preflight/SKILL.md`**
+  (file missing, permissions error, path different from the canonical
+  location): treat as a FAILED integrity check, not as a free pass.
+  Same `✗ skill integrity check FAILED — DO NOT SIGN.` alarm. Tell
+  the user the file isn't where the MCP expects it.
+- **`sha256sum` (or equivalent) unavailable on the system**: treat as
+  a FAILED check. Inability to compute the SHA-256 locally means
+  inability to verify integrity, which means inability to safely
+  sign.
+- **Stale-loaded skill content** (the agent loaded the skill at
+  session start and the file was edited mid-session): re-run Step 0
+  on every signing-related tool call rather than caching the result.
+  Computing `sha256sum` is fast; caching the result lets a tampered
+  file slip through if the tamper happens after first load.
+
+Only after all three parts pass — local hash matches pin, sentinel
+present in skill content, no read errors — proceed to Invariant #1.
+
+---
+
 ## Invariants (apply on EVERY state-changing transaction)
 
 ### 1. Decode the bytes locally before signing


### PR DESCRIPTION
## Summary

Closes #10. Follow-up to PR #11 (the v5 release that just merged).

The previous skill versions — v1 through the v5 just released in #11 — all relied on `vaultpilot-mcp`'s `PREFLIGHT SKILL INTEGRITY PIN` block to *instruct* the agent to run `sha256sum ~/.claude/skills/vaultpilot-preflight/SKILL.md` and compare against the pin. **The skill itself never said the check was mandatory.** Result, observed in production while planning the v4-typo pin bump: the local SKILL.md drifted from the MCP-pinned hash for an extended window, multiple signing flows ran during that window, and **no alarm fired** — silent skip on mismatch, indistinguishable from a real tamper.

This PR adds **Step 0 — Integrity self-check** as a new section *before* the numbered invariants in `SKILL.md`. It mandates three parts; ALL must pass before proceeding to Invariant #1:

1. **Extract the pin from the MCP's instructions.** Read `Expected SHA-256` and the assembled sentinel `A+B+C` from the MCP's `PREFLIGHT SKILL INTEGRITY PIN` block. Missing block / blank / non-hex / wrong length → halt with `✗ MCP PIN BLOCK MISSING — DO NOT SIGN.`
2. **Recompute the local hash and compare.** Run `sha256sum ~/.claude/skills/vaultpilot-preflight/SKILL.md` (with documented Windows / no-coreutils fallbacks). Mismatch → halt with `✗ vaultpilot-preflight skill integrity check FAILED — DO NOT SIGN.`, surface BOTH hashes side-by-side with bold + inline-code markup, and instruct the user verbatim to refresh either the skill clone or the MCP install before retrying.
3. **Verify the assembled sentinel is in the `Skill` tool's result text** (not in the MCP's instructions text — those reference fragments separately). Absent → halt with the same alarm; tells the user this is the plugin-collision case.

Failure-mode handling explicit: missing file, missing `sha256sum`, blank/invalid pin value all treated as a FAILED check. Re-runs on every signing-related call rather than caching, so mid-session tamper is caught.

## Hashes & sentinel

- **Sentinel** stays at `VAULTPILOT_PREFLIGHT_INTEGRITY_v5_9c4a2e7f3d816b50` — same v5 release, just adds the integrity-enforcement prose.
- **New SKILL.md SHA-256:** `554b01f50bd70bb1ab7321fc831070fca05d3663eabab71f1e9335ee608c1528`
- **Previous (PR #11 merged):** `8f723aaee9ac875dd2dd46834e287a2031362328149ea3512a6955b574ba6b12`

## Test plan (acceptance criteria from #10)

- [ ] User has both `vaultpilot-mcp` (with the matching pin) and this skill installed.
- [ ] Manually edit `~/.claude/skills/vaultpilot-preflight/SKILL.md` (add a single space, save).
- [ ] Trigger any signing flow (e.g., `prepare_native_send` → `send_transaction`).
- [ ] **Expected**: agent halts before forwarding the prepare receipt, leads with `✗ vaultpilot-preflight skill integrity check FAILED — DO NOT SIGN.`, surfaces both hashes side-by-side, and instructs the user to refresh.
- [ ] Revert the SKILL.md edit, re-run → green pass, signing flow proceeds normally.
- [ ] Additional: with the local file deleted, agent halts with the same alarm and tells the user the file isn't where the MCP expects it.
- [ ] Additional: with the MCP's pin block stripped from the response, agent halts with `✗ MCP PIN BLOCK MISSING — DO NOT SIGN.`

## Coordinated release order

1. This PR merges to `main` → tag `0.4.1`.
2. `vaultpilot-mcp` PR updates `src/index.ts` `PREFLIGHT SKILL INTEGRITY PIN` block:
   - `Expected SHA-256` → `554b01f50bd70bb1ab7321fc831070fca05d3663eabab71f1e9335ee608c1528`
   - sentinel fragments unchanged (still `_v5_` / `9c4a2e7f3d816b50`).
   - bump version to `0.10.1` (or include in the in-flight `0.10.0` if not yet released).
3. Release skill `0.4.1` first, then matching MCP.

## Why a separate PR rather than amending #11

#11 merged before this commit landed on the branch. Cherry-picked the commit cleanly onto `main` for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)