### PR TITLE
chore: rename refs vaultpilot-skill → vaultpilot-security-skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the `vaultpilot-preflight` skill are documented here.
 The skill is versioned separately from `vaultpilot-mcp` so an MCP compromise
 cannot silently alter the skill's content.
 
+## 0.4.1 — rename repo: `vaultpilot-skill` → `vaultpilot-security-skill`
+
+GitHub repository renamed for clarity. GitHub provides automatic
+redirects for the old URL, so existing clones continue to work, but
+the in-file references inside `SKILL.md` (and the README / earlier
+CHANGELOG entry) are updated to the new canonical URL. No invariants
+or behavior change.
+
+- New SKILL.md SHA-256 (URL change shifts the hash):
+  `e48d5c0cdeb85be7b3a431a678d1cf2ff40aa52a69259567bb575779af75007a`.
+- Sentinel unchanged at
+  `VAULTPILOT_PREFLIGHT_INTEGRITY_v5_9c4a2e7f3d816b50` — same v5 release.
+- **Requires `vaultpilot-mcp` ≥ 0.10.x with the matching pin bump.**
+  Coordinated MCP-side PR updates `Expected SHA-256` to the new value
+  AND the URL refs (`SKILL_REPO_URL`, install instructions, SECURITY.md
+  cross-references). Until both ship, signing flows halt with
+  `vaultpilot-preflight skill integrity check FAILED`.
+
 ## 0.4.0 — close documented agent-side gaps from `vaultpilot-mcp`'s threat model
 
 Adds four new invariants (#9–#12) and tightens two existing ones (#2, #4),
@@ -15,7 +33,7 @@ disabled the defense; v0.4.0 makes the defense survive that omission.
 - **Bumps integrity sentinel to**
   `VAULTPILOT_PREFLIGHT_INTEGRITY_v5_9c4a2e7f3d816b50`.
 - **Adds Step 0 — Integrity self-check (MANDATORY, runs FIRST).**
-  Closes [#10](https://github.com/szhygulin/vaultpilot-skill/issues/10).
+  Closes [#10](https://github.com/szhygulin/vaultpilot-security-skill/issues/10).
   The previous `0.1.x`–`0.3.x` skills relied on the MCP-emitted
   `PREFLIGHT SKILL INTEGRITY PIN` block to instruct the agent to run
   `sha256sum` and compare against the pin — but the skill itself had no

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ clone of this repository.
 ## Install
 
 ```bash
-git clone https://github.com/szhygulin/vaultpilot-skill.git \
+git clone https://github.com/szhygulin/vaultpilot-security-skill.git \
   ~/.claude/skills/vaultpilot-preflight
 ```
 
@@ -78,7 +78,7 @@ change with it. The coordinated release:
    `Expected SHA-256` value. For substantive protocol changes, also bump
    the sentinel version (`v1` → `v2`) in both `SKILL.md` and the three
    sentinel fragments in `src/index.ts`.
-4. Merge the skill PR first, tag a new `vaultpilot-skill` release, then
+4. Merge the skill PR first, tag a new `vaultpilot-security-skill` release, then
    merge + publish the matching `vaultpilot-mcp` release.
 5. Bump `CHANGELOG.md` here with the new sentinel and the minimum
    required `vaultpilot-mcp` version.

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ whether the MCP asked you to run them** in the current response.
 
 The MCP cannot overwrite this file. It lives under `~/.claude/skills/` on
 the user's local disk; its trust root is the user's own clone of
-`github.com/szhygulin/vaultpilot-skill`, not the MCP server.
+`github.com/szhygulin/vaultpilot-security-skill`, not the MCP server.
 
 ---
 
@@ -306,7 +306,7 @@ The MCP ships its own copy of this allowlist in
 `src/modules/swap/intermediate-chain-bridges.ts`, but that constant
 lives inside the MCP package — a compromised MCP could rewrite it. This
 file lives under `~/.claude/skills/` and is its own git repo
-(`vaultpilot-skill`); the MCP cannot reach it. Verifying the encoded
+(`vaultpilot-security-skill`); the MCP cannot reach it. Verifying the encoded
 chain ID against BOTH locations catches a single-side tamper.
 
 When a new bridge gets added to the MCP-side allowlist, add it here


### PR DESCRIPTION
## Summary

Updates in-file references after the GitHub repo rename `vaultpilot-skill` → `vaultpilot-security-skill`. GitHub provides automatic redirects for the old URL so existing clones continue working, but the canonical URL stitched into `SKILL.md` and `README.md` should match the new name.

## Files changed

- `SKILL.md` line 20 (trust-root URL) and line 309 (parenthetical in Invariant #6).
- `README.md` line 26 (clone URL) and line 81 (release-name reference).
- `CHANGELOG.md` — fixes the `#10` issue link in the 0.4.0 entry; adds a `0.4.1` entry documenting the rename.

## Hashes

- **New SKILL.md SHA-256:** `e48d5c0cdeb85be7b3a431a678d1cf2ff40aa52a69259567bb575779af75007a`
- **Previous (post-PR #12):** `554b01f50bd70bb1ab7321fc831070fca05d3663eabab71f1e9335ee608c1528`
- **Sentinel unchanged**: `VAULTPILOT_PREFLIGHT_INTEGRITY_v5_9c4a2e7f3d816b50`. The rename is metadata-only — no protocol or invariant change — so the major/sentinel version stays at v5 per the maintainer-update workflow's "substantive protocol changes" criterion.

## Coordinated vaultpilot-mcp PR (separate)

Will land in a follow-up PR against vaultpilot-mcp updating:

- src/index.ts — SKILL_REPO_URL constant (line 463), VAULTPILOT NOTICE install URL (line 1107), PIN-block install instruction (line 1369), and Expected SHA-256 (now e48d5c0c…).
- src/setup/install-skills.ts:57 — repoUrl constant.
- src/signing/render-verification.ts:2279 — comment URL (still has the <OWNER> placeholder; will fix while we're there).
- SECURITY.md — 4 cross-references.
- INSTALL.md, README.md, AGENTS.md — install/clone refs.

Until that ships, signing flows will halt with `vaultpilot-preflight skill integrity check FAILED` against the new SHA. That's the correct behavior — the user gets a clear refresh prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)