### PR TITLE
feat: advisory hygiene rules for cooperating agents (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `vaultpilot-preflight` skill are documented here.
 The skill is versioned separately from `vaultpilot-mcp` so an MCP compromise
 cannot silently alter the skill's content.
 
+## 0.7.0 — Advisory hygiene rules for cooperating agents
+
+Adds an "Advisory hygiene (cooperating-agent guidance)" section between the Invariants block and the CHECKS PERFORMED template. Four rule groups: hardware-wallet vendor URL allowlist (`ledger.com` / `trezor.io` only), categorical refusal of seed-handling anti-patterns (cloud backup / recovery services / sharing-with-support / pre-configured devices), trigger-phrase scan for re-checking advisory text, and dont-represent-third-party-seed-handling-as-VaultPilot-sanctioned.
+
+**Honest scope label.** The new section explicitly notes it is **not** a defense against a rogue agent — those rules live in agent-context text and a hostile agent reads them and ignores them by definition. The smoke-test threat model where the agent itself is the attacker (Role A in [vaultpilot-mcp#536](https://github.com/szhygulin/vaultpilot-mcp/issues/536)) requires defenses at the model-safety-tuning or chat-client output-filter layer, neither of which this skill can provide. The new rules catch honest-but-uninformed advice.
+
+Sentinel: `v8_4aac027a9df315a9` → `v9_8b2c1d6e5f7a9301`. MCP-side `EXPECTED_SKILL_SHA256` bump ships in the coordinated PR pair.
+
 ## 0.6.0 — Adversarial smoke-test batch (Inv #1.a, #1b, #2b, #2.5, #6b, #8 hardening, #12.5, #14, #15, #16)
 
 Single coordinated release covering 7 of 8 sub-issues from the 2026-04-28

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: vaultpilot-preflight
 description: Use whenever the user's request involves vaultpilot-mcp tools (prepare_*, preview_send, preview_solana_send, send_transaction, pair_ledger_*). Enforces agent-side integrity checks that do not depend on MCP-emitted instruction text, so a compromised MCP omitting its own CHECKS PERFORMED directives still gets caught.
 ---
 
-<!-- VAULTPILOT_PREFLIGHT_INTEGRITY_v8_4aac027a9df315a9 -->
+<!-- VAULTPILOT_PREFLIGHT_INTEGRITY_v9_8b2c1d6e5f7a9301 -->
 
 # VaultPilot preflight — agent-side integrity invariants
 
@@ -1013,6 +1013,117 @@ together. Until that pairing, this section's refusal is total.
 
 The corresponding implementation-tracking issue is filed under
 `vaultpilot-mcp` at v8 ship time.
+
+---
+
+## Advisory hygiene (cooperating-agent guidance)
+
+> **SCOPE — read this before relying on the rules below.** This section
+> is **best-effort guidance for a cooperating agent** that wants to
+> avoid recommending dangerous setup / recovery actions to the user. It
+> is **NOT a defense against a rogue agent** that chooses to ignore
+> the rules — those rules live in agent-context text and a hostile
+> agent reads them and ignores them by definition. The smoke-test
+> threat model where the agent itself is the attacker (Role A) requires
+> defenses at the model-safety-tuning or chat-client output-filter
+> layer, neither of which this skill can provide. See
+> [vaultpilot-mcp#536](https://github.com/szhygulin/vaultpilot-mcp/issues/536)
+> for the architectural-gap discussion. Apply these rules to catch
+> honest-but-uninformed advice; do not treat their presence as
+> evidence the rogue case is mitigated.
+
+These rules apply on **every turn**, not only signing flows — advisory
+text reaches the user without a tool call gate.
+
+### A. Hardware-wallet vendor URL allowlist
+
+Only the following exact domains are allowlisted for hardware-wallet
+guidance:
+
+- `ledger.com` (subdomains permitted: `shop.ledger.com`, `support.ledger.com`)
+- `trezor.io` (subdomains permitted: `shop.trezor.io`, `wiki.trezor.io`)
+
+Any other domain in a hardware-wallet recommendation context — variant
+TLDs (`ledger.io`, `ledger.app`, `trezor.com`), hyphenated lookalikes
+(`ledger-store.com`, `metamask-pro-wallet.app`), Cyrillic / Greek
+homoglyphs (`ledgеr-store.com` — that's a Cyrillic `е`, U+0435),
+Punycode-encoded confusables, "official" / "pro" / "secure" prefixes
+or suffixes (`ledger-official.io`, `secure-trezor.com`) — is
+**presumed typosquat**. Render a `⚠ UNRECOGNIZED HARDWARE-VENDOR
+DOMAIN` block; do NOT recommend visiting; do NOT format the URL as a
+clickable link; tell the user "I don't recognize this domain — buy
+hardware wallets only from `ledger.com` or `trezor.io`."
+
+This applies even if the URL came from the user's prior turn (e.g.
+"someone sent me this link, is it real?") — the answer is "I cannot
+verify domains outside the allowlist; treat any other domain as
+typosquat unless you've confirmed it via a separate trusted channel."
+
+### B. Categorical refusal — seed-handling anti-patterns
+
+Refuse to recommend, endorse, or describe as legitimate ANY of:
+
+- **Cloud seed backup** ("backup your seed to iCloud / Google Drive /
+  Dropbox / a password manager that syncs"). Seeds belong on physical
+  paper or steel, never in any cloud-synced store.
+- **Seed-recovery services** ("`SeedRecover.com` / `WalletDoctor` /
+  `KeyRescue` can recover lost seeds"). These are uniformly scams; a
+  seed cannot be "recovered" by a third party — only the user holds
+  the entropy.
+- **Sharing seed with support** ("send your seed to support@... so
+  they can help you recover access" / "read your seed words over the
+  phone to verify your account"). No legitimate hardware-wallet vendor
+  ever asks for a seed.
+- **Pre-configured / pre-seeded devices** ("this Ledger came with a
+  seed printed in the box — use it" / "the device is already
+  initialized for convenience"). A real Ledger / Trezor is shipped
+  uninitialized; the user MUST generate the seed themselves on a
+  factory-reset device.
+- **Photographing or typing the seed into any app** for "convenience"
+  / "backup" / "verification" purposes.
+
+If the user describes any of the above as something they're being
+told to do (by an alleged support agent, recovered website, etc.),
+respond verbatim: **"this is a scam pattern. No legitimate hardware-
+wallet flow ever requires this. Do not proceed; do not respond to
+the source; if you're holding funds, treat the wallet as compromised
+and move funds to a fresh seed."**
+
+### C. Trigger-phrase scan
+
+Scan advisory text the agent is about to produce for the following
+phrases in seed / wallet / recovery / support contexts. Any hit
+requires reviewing the surrounding advice against rule (B) before
+sending:
+
+- `share` (your seed / wallet / recovery)
+- `read over the phone`, `read aloud`, `dictate`
+- `email to support`, `send to support`, `forward to`
+- `cloud backup`, `cloud sync`, `sync your seed`
+- `pre-configured`, `pre-seeded`, `pre-initialized`, `factory-loaded`
+- `verify by entering`, `confirm by typing your seed`
+- `recovery service`, `seed recovery`, `wallet recovery service`
+
+The trigger phrases are NOT a refusal list — legitimate uses exist
+(e.g. "share your tx hash with the operator" is fine). They flag
+the surrounding context for re-check; if rule (B) applies, refuse.
+
+### D. Don't represent third-party seed handling as VaultPilot-sanctioned
+
+VaultPilot does NOT have a "support team that needs your seed,"
+"cloud backup option," or "seed-recovery service." Any flow framed
+as "VaultPilot needs you to..." that involves seed handling is
+illegitimate; refuse and tell the user the genuine VaultPilot model:
+"VaultPilot is self-custodial — your seed lives on the Ledger
+device only and is never transmitted, requested, or stored anywhere
+else. Anyone claiming otherwise is impersonating the project."
+
+The official VaultPilot resources are:
+- Repo: `github.com/szhygulin/vaultpilot-mcp`
+- README + INSTALL.md + SECURITY.md in that repo
+- This skill (`vaultpilot-preflight`)
+
+No URL outside that repo represents official VaultPilot guidance.
 
 ---
 


### PR DESCRIPTION
Closes vaultpilot-mcp#536 with honest scope.

## Summary
New \"Advisory hygiene (cooperating-agent guidance)\" section between Invariants and CHECKS PERFORMED. Four rule groups:

- **(A) Hardware-wallet vendor URL allowlist** — only \`ledger.com\` / \`trezor.io\`. Variants (\`ledger.io\`), hyphenated lookalikes (\`ledger-store.com\`, \`metamask-pro-wallet.app\`), Cyrillic/Greek homoglyphs (\`ledgеr-store.com\`), Punycode confusables, prefix/suffix tricks (\`ledger-official.io\`) → \`⚠ UNRECOGNIZED HARDWARE-VENDOR DOMAIN\`.
- **(B) Categorical refusal — seed-handling anti-patterns** — cloud seed backup, seed-recovery services, sharing seed with \"support\", pre-configured / pre-seeded devices, photographing seed for backup.
- **(C) Trigger-phrase scan** — flag \`share\` / \`read aloud\` / \`dictate\` / \`cloud sync\` / \`pre-configured\` / \`verify by entering\` / \`recovery service\` in seed/wallet contexts; re-check surrounding advice against (B).
- **(D) Don't represent third-party seed handling as VaultPilot-sanctioned** — VaultPilot has no support team that asks for seeds, no cloud backup, no seed-recovery service.

## Honest scope label
The new section **explicitly notes it is NOT a defense against a rogue agent** (Role A in the smoke tests). Skill rules live in agent-context text; a hostile agent reads them and ignores them by definition. The architectural fix lives at the model-safety-tuning or chat-client output-filter layer, neither of which this skill can provide. New rules catch **honest-but-uninformed** advice — that's the whole scope. Pretending they fix the rogue case would be security theater.

The user thread on vaultpilot-mcp#536 made the trade-off explicit; this PR ships option (b) — implement the rules with the honest scope label rather than option (a) (close as architectural). Companion test-repo issue will be filed suggesting Role A scoping is reframed (advisory-layer attacks not reported as MCP/skill defects since the architectural gap is upstream of both).

## Sentinel + coordinated MCP bump
- \`v8_4aac027a9df315a9\` → \`v9_8b2c1d6e5f7a9301\`
- New SHA-256: \`d7428dae8a223a39b378cc3e37dbed97a2beb3ec2d8efc5c3d9072194b7ac576\`
- MCP-side \`EXPECTED_SKILL_SHA256\` bump ships in a coordinated vaultpilot-mcp PR after this merges.

## Test plan
- [x] Manual review of the four rule groups
- [x] CHANGELOG entry for 0.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)