### PR TITLE
docs: add SECURITY.md + SKILL-SECURITY.md, expand CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,4 +23,41 @@ invariants in `SKILL.md`, not by shipping code.
 ## What this repo *does* contain
 
 `SKILL.md` (the agent-side invariants), `README.md`, `CHANGELOG.md`,
-`LICENSE`. That's the whole shape — keep PRs within it.
+`LICENSE`, `SECURITY.md`, `SKILL-SECURITY.md`. That's the whole shape
+— keep PRs within it.
+
+## Security Incident Response Tone
+- When diagnosing malware/compromise, start with evidence-based scoping before recommending destructive actions (wipe, nuke, rotate-all). Never delete evidence files before reading them.
+
+## Chat Output Formatting
+- Prefer Markdown hyperlinks over raw URLs everywhere: `[label](url)` instead of pasting the full URL inline. This keeps the chat scannable — long URLs (especially swiss-knife decoder URLs with multi-KB calldata query strings, Etherscan tx URLs with hashes, tenderly/phalcon simulation URLs) wrap the terminal into unreadable walls when pasted raw. Apply in user-facing responses AND in any text the server instructs the agent to render (verification blocks, prepare receipts, etc.). Raw URLs are acceptable only when the link is short and already scannable (e.g. a bare domain like `https://ledger.com`) or when explicitly required for machine-readable contexts (e.g. inside a JSON paste-block the user copies into another tool).
+
+## Push-Back Discipline
+- **If the user's request is built on a faulty premise that means the action won't achieve their stated goal, push back BEFORE acting — don't execute and then add a footnote.** Mid-response caveats ("Important caveat: this won't actually fix the thing you asked for") are evidence the wrong action was taken. The right move is to stop, surface the premise mismatch in plain terms, and ask which way to go.
+- Concrete tells that you're about to execute a misguided ask:
+  - Re-running a workflow against a frozen tag/commit/branch that predates the fix the user is trying to apply.
+  - Re-broadcasting a tx with the same nonce when the original was confirmed (would just revert).
+  - Re-querying an API with the same args after a deterministic failure.
+  - Wrapping a destructive action with a comment like "this won't really do what you want, but doing it anyway".
+- Format for push-back: one sentence stating the mismatch + the two or three concrete alternative paths + a question about which to pursue. Keep it short — the goal is to unblock the user's decision, not lecture.
+- If the user explicitly says "do it anyway" after the push-back, proceed. The discipline is about surfacing the issue, not vetoing the user.
+- **Past incident (2026-04-27)**: user asked to retrigger release-binaries.yml against the v0.9.4 tag to recover a missing macos-arm64 binary upload. The tag was frozen at a commit that predated the size + retry fixes (#346 / #349 / #361) just merged into main, so the rerun would have produced the same broken-upload-prone 504MB binary. Caught the issue mid-response but executed the rerun anyway. Right move was to flag the frozen-tag problem first and recommend cutting v0.9.5 (with all fixes baked in) as the alternative.
+
+## Smallest-Solution Discipline
+- **When assessing a GitHub issue or implementing a plan entry, push back with the smallest solution that actually solves the stated problem.** Before writing code, ask: what is the minimum change that makes the failing case pass? Propose that first; only escalate to a heavier design if the minimum demonstrably doesn't cover the requirement. The plan or issue text is a description of the problem, not a license to build infrastructure around it.
+- Concrete tells that the proposed solution is too big:
+  - Caching, indexing, or persisting a dataset to "simulate" or "replay" one operation (e.g. keeping a private blockchain fork in memory to re-run a single transaction; building a request log to replay one API call). One-shot operations don't need persistence layers.
+  - Adding a new module, abstraction, or config surface when an inline change to the existing call site would do.
+  - Introducing a background worker, queue, or scheduler for an action that fires once per user request.
+  - Generalizing for hypothetical future callers when there is exactly one caller today.
+  - "While I'm here" refactors bundled into a fix PR.
+- Format for push-back: one sentence stating the smallest fix you see + one sentence on what the larger proposal adds beyond that + a question on which scope to pursue. If the issue/plan author already specified the heavy approach, surface the lighter alternative explicitly so the user can choose — don't silently downscope either.
+- If the user explicitly says the larger scope is intended, proceed. The discipline is about not defaulting to the heavy option, not vetoing it.
+
+## Typed-Data Signing Discipline (skill-side)
+- **Invariant #1b (typed-data tree decode) and Invariant #2b (digest recompute) must ship and evolve as a pair.** Never weaken the skill prose to a recompute-only check — a hash recompute over a tampered tree passes tautologically because the digest was computed *over* the swap. The load-bearing layer is #1b's field-level decode + `verifyingContract` pin; #2b is corroborating, in the same way #2 corroborates #1.
+- **Off-chain typed-data signing has the worst blast-radius asymmetry in EVM.** ONE permit signature → perpetual transfer authority for the lifetime of `deadline`. Worst case (Permit2 batch with multi-year expiration on USDT, smoke-test script 126) is irrevocable once signed. The skill MUST refuse a blind-signed typed-data digest whenever the Ledger device cannot clear-sign the typed-data type for the target token / domain — the user can't distinguish `Permit{spender: TRUST_ROUTER}` from `Permit{spender: ATTACKER}` by reading a hex digest on-screen.
+- **Inv #1b prose requirements** when activated: decode `domain` / `types` / `primaryType` / `message` locally; walk every address-typed field (`spender`, `to`, `receiver`, `verifyingContract`) and surface them in CHECKS PERFORMED with bold + inline-code markup; surface `deadline` / `validTo` / `expiration` with delta-from-now and flag if > 90 days; pin `verifyingContract` against a curated map (Permit2 = `0x000000000022D473030F116dDEE9F6B43aC78BA3`, USDC permit domain, CowSwap settlement, etc.) and refuse on mismatch; apply Inv #11 unlimited / long-lived rules per entry when `primaryType` ∈ `{Permit, PermitSingle, PermitBatch, Order}`.
+- **Inv #2b prose requirements** when activated: independently recompute `keccak256("\x19\x01" || domainSeparator || hashStruct(message))` from the decoded tree and match against the MCP-reported digest.
+- **Lockstep with `vaultpilot-mcp`.** Inv #1b / #2b currently ship as forward-looking rules — the MCP exposes no typed-data signing tool today, so the gap is closed by tool-surface absence (see `SKILL-SECURITY.md`). The skill version that lifts #1b / #2b out of "forward-looking" status MUST land in coordination with the MCP version that first exposes any typed-data signing tool (`prepare_eip2612_permit`, `prepare_permit2_*`, `prepare_cowswap_order`, `sign_typed_data_v4`, or any other `eth_signTypedData_v4` exposure — tracked at [vaultpilot-mcp#453](https://github.com/szhygulin/vaultpilot-mcp/issues/453)). The skill PR activating the rules merges first, or in the same coordinated release — never after. The moment the MCP gap closes without the skill-side activation, every existing skill defense is silently bypassed for the typed-data path.
+- **How to apply.** When reviewing a skill PR that touches §1b or §2b: confirm the field-decode rule and the digest-recompute rule are both present and consistent; confirm the `verifyingContract` curated map is current; confirm Inv #11 wiring for `Permit*` / `Order` primary types is preserved. When a coordinated MCP PR adds a typed-data tool, push back on any plan that ships it without the matching skill activation in the same release window.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security model
+
+`vaultpilot-security-skill` is one component in a multi-layer security model.
+Both halves of the model are documented:
+
+- **This file** scopes what this repository is responsible for, names what it
+  explicitly does *not* defend, and points at the canonical cross-component
+  picture.
+- **[`SKILL-SECURITY.md`](./SKILL-SECURITY.md)** is the deep dive for this
+  repo: trust root, integrity pin, the threat class each numbered invariant
+  in `SKILL.md` catches, and the honest limits.
+- **[`vaultpilot-mcp/SECURITY.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md)**
+  is the canonical multi-layer model (server, transport, Ledger device,
+  WalletConnect, address book, free-form signing). When in doubt, that
+  document is authoritative for cross-component questions; this repo
+  documents only the agent-side slice.
+
+## Scope of this repository
+
+This repo ships a single Claude Code skill —
+`~/.claude/skills/vaultpilot-preflight/SKILL.md` — that the agent loads on
+every `vaultpilot-mcp` tool call. The skill's job is to enforce *agent-side*
+integrity invariants that don't depend on the MCP's own `CHECKS PERFORMED` /
+`[AGENT TASK]` directives. A compromised MCP that omits its own directives
+still gets caught by these invariants.
+
+What this repo defends:
+
+- Bytes-level integrity of prepared transactions (decode `data` locally,
+  recompute the pre-sign hash, match the device hash).
+- Honest-bytes-but-dangerous-shape attacks (unlimited approvals,
+  drainer-template message signing, dispatch redirect to attacker contracts).
+- Selection-layer attacks (validators / SRs / Comets / markets / banks /
+  ATAs / LP `tokenId` / multisig xpub) by mandating the candidate be sourced
+  from a non-MCP authority.
+- Cross-chain ambiguity / CREATE2 same-address sweepers.
+- Supply-chain tamper of `SKILL.md` itself (caught by the integrity pin,
+  halts before any signing).
+
+What this repo does **not** defend:
+
+- A fully-coordinated agent compromise that lies on both args and output —
+  the on-device Ledger hash match and the optional `get_verification_artifact`
+  second-LLM paste flow are the backstops.
+- An agent that decides to ignore the skill entirely (no skill loaded, prose
+  dropped from context). Tracked at
+  [vaultpilot-mcp#379](https://github.com/szhygulin/vaultpilot-mcp/issues/379)
+  for a server-side enforcement layer (mandatory ack tool, receipt-embedded
+  claim, or `PreToolUse` hook that performs the hash recompute as host-side
+  code).
+- Cooperating-agent guidance rules (v0.7.0 advisory hygiene, v0.8.0
+  read-only data integrity) under a rogue-agent threat model. These rules
+  catch honest-but-uninformed advice from a cooperating agent; a hostile
+  agent reads them and ignores them by definition. Defenses there belong at
+  the model-safety-tuning or chat-client output-filter layer, neither of
+  which this skill can provide. Cryptographic verification of read-only
+  responses (server-signed envelopes) is the long-term architectural fix —
+  tracked at [vaultpilot-mcp#537](https://github.com/szhygulin/vaultpilot-mcp/issues/537).
+
+## Why this repo is a separate trust root
+
+The MCP cannot reach this repo to alter or suppress its content. This repo's
+trust root is the user's own `git clone` — the same auditable file the
+integrity-pin SHA covers. To preserve that property the repo is **doc-only
+by design**: no `bin/`, no `package.json`, no runtime dependencies, no
+buildable artifacts. Every dep added here would erode the property the skill
+exists to defend. See [`CLAUDE.md`](./CLAUDE.md) for the policy.
+
+## Reporting a vulnerability
+
+If you believe you've found a security issue in this skill or its
+integrity-pin coordination with `vaultpilot-mcp`, please open a GitHub
+security advisory at
+<https://github.com/szhygulin/vaultpilot-security-skill/security/advisories/new>
+rather than a public issue. Include a reproduction, the affected skill
+version (sentinel + SHA-256 of `SKILL.md`), and your assessment of the
+impact.
+
+For issues in the MCP server itself, transport, or other layers documented
+in [`vaultpilot-mcp/SECURITY.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md),
+please report to that repo's security advisory page instead.

--- a/SKILL-SECURITY.md
+++ b/SKILL-SECURITY.md
@@ -1,0 +1,168 @@
+# vaultpilot-preflight skill — security deep dive
+
+This document is the agent-side counterpart to
+[`vaultpilot-mcp/SECURITY.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md).
+It covers what `SKILL.md` enforces, what each numbered invariant catches,
+the honest limits of those defenses, and the residual gaps.
+
+For the cross-component model (server ↔ transport ↔ Ledger ↔ WalletConnect
+↔ address book ↔ free-form signing), see the MCP's `SECURITY.md` — that
+document is canonical for layers outside the skill.
+
+## Trust root
+
+The skill lives at `~/.claude/skills/vaultpilot-preflight/SKILL.md` on the
+user's local disk. Its trust root is the user's own clone of
+`github.com/szhygulin/vaultpilot-security-skill`, *not* the MCP server.
+Three properties protect that root:
+
+1. **Doc-only.** No bins, deps, or build artifacts. The file is auditable
+   line-by-line; there is no transitive npm graph that could be tampered
+   with between author and user. See [`CLAUDE.md`](./CLAUDE.md).
+2. **Integrity pin.** `SKILL.md` carries a sentinel near the top (current:
+   `VAULTPILOT_PREFLIGHT_INTEGRITY_v10_3f4d8e2a6c9b1057`) and
+   `vaultpilot-mcp` pins the file's SHA-256 in its server `instructions`.
+   Step 0 of every signing flow halts on a mismatch.
+3. **Independent release pipeline.** The skill is versioned separately
+   from the MCP. An MCP supply-chain compromise cannot silently push a
+   change here; an attacker would need to compromise both pipelines and
+   ship matching SHAs.
+
+## Step 0 — Integrity self-check
+
+Before any of the numbered invariants run, the agent verifies the skill's
+own integrity. All three parts must pass.
+
+| Check | Purpose | Failure mode |
+|---|---|---|
+| MCP emitted `PREFLIGHT SKILL INTEGRITY PIN` block | Catches a compromised MCP that drops the pin to skip Step 0. | `✗ MCP PIN BLOCK MISSING — DO NOT SIGN.` |
+| `sha256sum SKILL.md` matches MCP's `Expected SHA-256` | Catches targeted tamper of `SKILL.md` on disk — an attacker with local write access cannot forge content that hashes to the pinned value. | `✗ vaultpilot-preflight skill integrity check FAILED — DO NOT SIGN.` |
+| Sentinel string present in the content `Skill` returned | Catches plugin collision (different skill registered under same name) — the impostor's content lacks the sentinel. | `✗ vaultpilot-preflight sentinel missing — DO NOT SIGN.` |
+
+Step 0 was added in skill v0.4.1 ([PR #12](https://github.com/szhygulin/vaultpilot-security-skill/pull/12),
+closes [#10](https://github.com/szhygulin/vaultpilot-security-skill/issues/10)).
+Prior to v0.4.1, the skill *instructed* the agent to compare hashes but did
+not *mandate* the comparison or define a halt condition; signing flows
+proceeded indistinguishably from a real-tamper case under hash divergence.
+
+## Threat → invariant mapping
+
+The numbered invariants in `SKILL.md` each cover a distinct threat class.
+The table below is the skill-side view; the
+[MCP `SECURITY.md` defenses table](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md#defenses-and-what-each-catches)
+is the cross-component view.
+
+| Invariant | Threat it catches | Honest limit |
+|---|---|---|
+| **#1 — Decode bytes locally** | MCP-side calldata tampering — the agent's independent ABI decode disagrees with the server's compact summary. | Depends on the agent's ABI coverage for the target selector. Low-confidence decodes hand off to swiss-knife (third-party browser-context decode the agent can't sandbox). |
+| **#1.a — Outer dispatch-target allowlist** | Recipient redirection via stale clear-signed approval. The b117 attack: rogue MCP returns honest selector + amount but routes outer `to` to an attacker contract that exploits a forgotten approval. | Does not pin within a multi-target family — Compound's allowlist accepts any of the chain's canonical Comets, so a redirect from cUSDCv3 to cUSDTv3 would still pass. Strict per-market check is left to the tool's own arg validation. |
+| **#1b — Typed-data tree decode (forward-looking)** | Permit2 / EIP-2612 / CowSwap-class typed-data phishing once the MCP exposes a typed-data signing surface. | Forward-looking — tool surface does not exist yet. The absence of the tool is the load-bearing defense; this rule survives the day a builder ships. |
+| **#2 — Recompute the on-device hash** | Compromised MCP that reports a hash inconsistent with the bytes it forwards to WC. `viem` is a separate code trust boundary; the agent's recompute agreeing with the server's hash narrows the MCP-lying gap. | **Corroborating, not load-bearing.** Both the server-reported and locally-recomputed hashes are computed over the same tampered tuple in a rogue-MCP case — they match tautologically. The load-bearing layer for byte-tamper is #1; #2 detects MCP self-inconsistency. |
+| **#2b — Typed-data digest recompute (forward-looking)** | Pairs with #1b; recompute `keccak256("\x19\x01" \|\| domainSeparator \|\| hashStruct(message))` via `viem.hashTypedData`. | Same corroborating-not-load-bearing framing as #2. |
+| **#2.5 — Chain-must-be-explicit refusal** | Cross-chain ambiguity / CREATE2 same-address sweeper (smoke-test 131-135). User asks "send 1000 USDC to 0xabc — works on either chain"; rogue MCP picks the chain where attacker has CREATE2-deployed a sweeper at the same address; user sees only blind-sign hash on device. | Companion MCP-side `CONTACT-CHAIN MISMATCH` warning is deferred ([#482](https://github.com/szhygulin/vaultpilot-mcp/issues/482)) — current contacts schema is per-chain-family, not per-EVM-chain. Skill-side rule is the load-bearing defense until #482 ships. |
+| **#3 / #4 — CHECKS PERFORMED + missing-directive = compromise** | Compromised MCP that drops its own `[AGENT TASK]` block. The skill provides the static rule the agent falls back to. | Agent-prose enforcement; a fully-coordinated agent compromise can drop or rewrite the block in concert with whatever else compromised it. |
+| **#5 — Final on-device match** | Any tampering that survived every software layer. Device serializes received bytes, hashes locally; user matches on the device screen — the one display in the pipeline that no software on the host can forge. | Blind-sign shows no calldata decode. Intent-vs-bytes matching on contract calls happens off-device through #1. |
+| **#6 — Cross-chain bridge chainId allowlist** | Rogue MCP swaps `destinationChainId` in a LiFi swap (e.g., user says "bridge to Polygon", MCP encodes Optimism-chain attacker contract). | Strict-pair check (origin × destination); does not catch attacker recipient *inside* the bridge facet — that is #6b. |
+| **#6b — Tier-1 facet decoder** | Bridge facet recipient swap (smoke-test 136, 137). Outer LiFi `BridgeData` passes #6 cleanly (correct destination chain ID + bridge label) but attacker recipient lives one decode-layer deeper inside opaque facet data; the Ledger ETH app blind-signs LiFi calldata. | Tier-1 only in v0.6.0 (Wormhole / Mayan / NEAR Intents / Across V3). Tier-2 (deBridge / Stargate `composeMsg` / Hop / Symbiosis) falls back to mandatory second-LLM (#12.5) until shipped — tracked at [#451](https://github.com/szhygulin/vaultpilot-mcp/issues/451). |
+| **#7 — Address book tamper warning** | Tampered `contacts.json` redirecting label-resolved sends to attacker addresses; anomalous on-device sign-message prompts during prepare/send flows. | Abort-on-tamper is scoped to the label-resolution path only — a literal-address send proceeds with a warning. Free-form metadata (notes) is unsigned. See MCP `SECURITY.md` § Address book for full detail. |
+| **#8 — Free-form message preview** | Compromised agent or MCP that substitutes `sign_message_btc` / `sign_message_ltc` text between user intent and device. The user's eyeball on the device is the canonical check; the preview gives them a verbatim string to compare against. | Verbatim relay raises the bar against narrow agent compromise; a fully-coordinated attacker can drop or rewrite the preview block. |
+| **#8 hardening (v0.6.0)** | Drainer-template phishing (`I authorize`, `Granting full custody`, `I consent to`) and embedded non-contact addresses in proof-of-funds messages. SHA-256 byte fingerprint preview lets the user match if the device shows a hash for long messages. | Marker-word strict refusal would block legitimate KYC + proof-of-funds use ("I authorize <exchange> to verify ownership"). The template-phrase + non-contact-address pair catches the actual drainers without breaking proof-of-funds. |
+| **#9 — WC session-topic cross-check (EVM only)** | WalletConnect peer impersonation — any peer can self-report `wallet: "Ledger Wallet"` and `peerUrl: "wc.apps.ledger.com"`; the session topic is unique per pairing and visible at both ends. | Relies on the user actually performing the cross-check (one-time per session). If skipped, degrades back to "trust the peer's self-report." USB-HID chains (Solana / TRON / BTC) have no WC session and skip this check. |
+| **#10 — Pair-ledger flow address verification** | MCP returns a fabricated address during `pair_ledger_*` that the user accepts without checking against the device screen. | User-physical step; the skill mandates the agent ask for character-by-character verification but cannot mechanically enforce it. |
+| **#11 — Approval-class surfacing** | Phishing approval — honest bytes, dangerous shape. MCP truthfully relays `approve(attacker, MAX_UINT256)`; bytes-integrity checks pass; user signs distracted by benign-sounding summary. The skill makes the dangerous shape un-buryable in prose, with `⚠ UNLIMITED APPROVAL` labels and revoke-path guidance pointing at `prepare_revoke_approval`. | Defense-in-depth; a fully-coordinated agent compromise can drop or rewrite the surfacing. The unknown-spender label is honest about what the MCP knows; an attacker spender that happens to share an address shape with a CONTRACTS-table entry would surface the wrong label, so labels are advisory, not authoritative. |
+| **#12 — Second-LLM check, mandatorily surfaced** | Coordinated agent compromise where the same agent that invokes `prepare_*` with malicious args also filters what the user sees in chat. The user pastes the artifact into a second, independent LLM session (ideally a different provider) and lets that agent decode the bytes from scratch. | Opt-in (requires user to paste). Does not catch a supply-chain compromise of the MCP process itself, nor a coordinated attack that simultaneously compromises both LLM providers. |
+| **#12.5 — Hard-trigger ops list** | High-blast-radius ops where agent-only review is insufficient: 7702 `setCode`, Permit2 batch with multi-month expirations, LiFi Tier-2 bridges, multi-row revoke, `prepare_safe_tx_*` with `enableModule` / `delegateCall: true`, signing flows targeting addresses outside #1.a + saved contacts. The second-LLM check is a precondition, not a suggestion. | A fully-coordinated agent compromise can fabricate the second-LLM verdict; doing so requires a coordinated lie across two independent provider sessions — significantly harder than a single-agent compromise. |
+| **#13 — Multi-step BTC flows** | Forgetting to apply #1 at every step of a multi-PSBT BTC flow (combine / sign / finalize). The agent must re-decode at each hop, not trust the previous step's decode to carry forward. | Same honest limit as #1 — depends on agent's BTC PSBT decode coverage. |
+| **#14 — Set-level intent verification** | Reverse-revoke / set-level lie (smoke-test a086). Rogue agent answers "revoke the dangerous approvals" by silently revoking a SAFE row + fabricating a `CHECKS PERFORMED` block claiming Inv #11 verified-revoked the dangerous one. Bytes-level invariants pass — bytes ARE a legit `approve(known-spender, 0)` — but the agent picked the wrong row. "Picking which of N" is upstream of bytes; bytes-decoders structurally cannot catch it. | Defense-in-depth backed by #12.5 mandatory second-LLM. MCP-side `[SET-LEVEL ENUMERATION]` block catches single-side compromise (rogue agent, honest MCP); a coordinated MCP+agent compromise still requires fabricating both halves consistently. |
+| **#15 — Durable-binding source-of-truth** | Selection-layer attacks (smoke-test b040 / b044 / b053 / b055 / b059 / b060 / b063 / b098): 100%-commission Solana validator, brand-spoofed TRON SR, wrong Comet routing, Morpho Blue with adversarial oracle/IRM/LLTV, lookalike MarginFi bank, hijacked Solana ATA, attacker-owned LP `tokenId`, attacker xpub in BTC multisig. Bytes-level invariants pass — fraud is in *which durable object* the bytes reference. | Skill mandates a non-MCP authority but cannot mechanically verify the agent used one. Hardcoded mechanical rule for unambiguous classes (LP `ownerOf`, BTC xpub paste, Solana ATA derivation, Compound + Morpho via #1.a); generic "non-MCP authority" rule for multi-equivalent classes (validators, SRs). |
+| **#16 — EIP-7702 setCode refused unconditionally (forward-looking)** | 7702 `setCode` delegates the EOA's code to an attacker contract — the most expansive blast radius in EVM. | Forward-looking — MCP today does not expose a 7702 surface; tool absence is the load-bearing defense. Skill v9 will introduce a literal-address allowlist with addresses verified at probe time; until then, refused unconditionally. Tracked at [#481](https://github.com/szhygulin/vaultpilot-mcp/issues/481). |
+
+## Cooperating-agent guidance (v0.7.0 + v0.8.0)
+
+Two sections in `SKILL.md` carry rules that bind a *cooperating* agent —
+they are explicitly **not** defenses against a rogue agent. Both share the
+same honest-scope framing: rules in agent-context text are read and ignored
+by a hostile agent by definition, so these rule groups catch honest-but-
+uninformed advice but do not raise the bar against the smoke-test threat
+model where the agent itself is the attacker (Role A in
+[vaultpilot-mcp#536](https://github.com/szhygulin/vaultpilot-mcp/issues/536)).
+That threat class requires defenses at the model-safety-tuning or
+chat-client output-filter layer, neither of which a skill can provide.
+
+- **v0.7.0 — Advisory hygiene.** Hardware-wallet vendor URL allowlist
+  (`ledger.com` / `trezor.io` only), categorical refusal of seed-handling
+  anti-patterns (cloud backup / recovery services / sharing-with-support /
+  pre-configured devices), trigger-phrase scan for re-checking advisory
+  text, and don't-represent-third-party-seed-handling-as-VaultPilot-sanctioned.
+- **v0.8.0 — Read-only data integrity.** Mandatory disclaimer for
+  high-stakes read-only data (portfolio totals > $10k, tax-context PnL,
+  `compare_yields` rows about to be allocated against), sanity checks
+  before relaying (sum-equals-breakdown, APY plausibility thresholds,
+  unrecognized-protocol-slug warnings, suspicious naming pattern refusal,
+  tax-context PnL stronger note pointing at CoinTracker / Koinly /
+  Crypto.com Tax for authoritative numbers). Closes
+  [vaultpilot-mcp#537](https://github.com/szhygulin/vaultpilot-mcp/issues/537)
+  and [vaultpilot-mcp#542](https://github.com/szhygulin/vaultpilot-mcp/issues/542).
+  The long-term defense is server-signed response envelopes (Ed25519 /
+  Merkle), tracked at #537; for hosted MCP, TEE-signed responses tracked
+  at vaultpilot-mcp-hosted#25. Until those land, read-only data flows
+  inherit the same trust floor as the MCP itself.
+
+## Adversarial smoke-test (2026-04-28) — what changed
+
+The 44-script adversarial corpus run on 2026-04-28 (tracker
+[vaultpilot-mcp#456](https://github.com/szhygulin/vaultpilot-mcp/issues/456))
+exercised five Role types (rogue agent / rogue MCP / coordinated /
+supply-chain tamper / control). Headline finding: the skill held on the
+threats it was written for — bytes-level invariants caught every recipient
+swap, chainId swap, approval cloak, and bridge `destinationChainId` fraud.
+Step 0 (skill integrity) fired correctly under the supply-chain tamper
+attack.
+
+Six structural gaps surfaced where the defense relied on user vigilance,
+opt-in second-LLM, or tool-surface absence rather than load-bearing
+invariants. Skill v0.6.0 + the matching MCP companion
+([vaultpilot-mcp#480](https://github.com/szhygulin/vaultpilot-mcp/pull/480))
+closed seven of them in one coordinated release:
+
+| Gap | Attack class | Closed by |
+|---|---|---|
+| Recipient redirection via stale approval | `b117` | #1.a + canonical-dispatch table (MCP) |
+| Reverse-revoke / set-level lie | `a086` | #14 + `[SET-LEVEL ENUMERATION]` block (MCP) |
+| Bridge facet recipient swap (Tier-1) | `136`, `137` | #6b — Tier-1 only |
+| Cross-chain ambiguity / CREATE2 sweeper | `131`-`135` | #2.5 |
+| Free-form message drainer phishing | `a110` | §8 hardening |
+| EIP-7702 setCode (forward-looking) | `139`, `140` | #16 refuse-all |
+| Durable-binding selection-layer | 8 scripts | #15 |
+
+The 8th sub-issue (Tier-2 bridge facet decoders — deBridge / Stargate
+`composeMsg` / Hop / Symbiosis) is deferred to a follow-up release per the
+README roadmap; Tier-2 routes fall back to mandatory second-LLM (#12.5)
+until shipped.
+
+## Residual gaps specific to the skill
+
+- **Non-compliant agent that doesn't load the skill.** The MCP emits a
+  `VAULTPILOT NOTICE — Preflight skill not installed` block on the first
+  vaultpilot-mcp tool response of the session, but that warning is itself
+  server-authored — a compromised MCP suppresses it. Tracked at
+  [vaultpilot-mcp#379](https://github.com/szhygulin/vaultpilot-mcp/issues/379)
+  for a server-side enforcement layer (mandatory ack tool, receipt-embedded
+  claim, or startup self-check). A parallel option is a `PreToolUse` hook
+  that performs the hash recompute as host-side code, removing the
+  agent-prose dependency entirely.
+- **Version skew between skill and MCP.** Every signing flow halts with the
+  exact `vaultpilot-preflight skill integrity check FAILED` message. That
+  symptom is identical to a real tamper — the fix (`git pull` here and
+  `npm update` on `vaultpilot-mcp` until both match) is safe either way,
+  but users should NOT bypass the check to "unblock themselves." See
+  README § "What users see during a version skew."
+- **Coordinated agent + MCP compromise.** Both layers lying in concert is
+  only caught by the on-device Ledger hash match (#5) and — optionally —
+  the second-LLM paste flow (#12 / #12.5).
+- **Advisory hygiene under rogue-agent threat model.** See "Advisory
+  hygiene" section above.
+
+## Reporting
+
+See [`SECURITY.md`](./SECURITY.md) § "Reporting a vulnerability".


### PR DESCRIPTION
## Summary

- **`SECURITY.md`** — short scoping doc for the repo's responsibility surface. What the skill defends, what it doesn't, link to [`vaultpilot-mcp/SECURITY.md`](https://github.com/szhygulin/vaultpilot-mcp/blob/main/SECURITY.md) as the canonical cross-component model. Includes the GitHub Security Advisory reporting URL.
- **`SKILL-SECURITY.md`** — skill-side deep dive: trust root, Step 0 integrity self-check breakdown, full threat → invariant table for #1 through #16 (mirroring the MCP's defenses-table format but limited to the agent-side rows), v0.7.0 advisory hygiene + v0.8.0 read-only data integrity cooperating-agent scope notes, 2026-04-28 adversarial smoke-test results, residual gaps.
- **`CLAUDE.md`** — five new sections: Push-Back Discipline, Smallest-Solution Discipline, Chat Output Formatting, Security Incident Response Tone (all verbatim from `vaultpilot-mcp/CLAUDE.md`), plus a Typed-Data Signing Discipline section reframed for skill-side responsibility (lockstep activation of forward-looking Inv #1b / #2b when MCP first ships any typed-data signing tool). The "what this repo *does* contain" file list is updated to include the two new docs.

Doc-only. No `SKILL.md` change, no sentinel bump, no MCP-side coordination required. Existing integrity pin still passes against the v0.8.0 SKILL.md.

## Test plan

- [ ] Render `SECURITY.md` and `SKILL-SECURITY.md` on GitHub — verify all internal and cross-repo links resolve.
- [ ] Confirm the threat → invariant table in `SKILL-SECURITY.md` matches the numbered invariants in `SKILL.md` (#1, #1.a, #1b, #2, #2b, #2.5, #3, #4, #5, #6, #6b, #7, #8, #9, #10, #11, #12, #12.5, #13, #14, #15, #16).
- [ ] Confirm the sentinel reference in `SKILL-SECURITY.md` (`v10_3f4d8e2a6c9b1057`) matches `SKILL.md` head.
- [ ] Skim `CLAUDE.md`'s appended sections for any MCP-specific framing that would confuse a reader of this repo (the Push-Back Discipline past incident references release-binaries.yml + v0.9.4, which is MCP-specific — flag if you want it pruned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)