### PR TITLE
chore(claude-md): migrate generic rules to user-global ~/.claude/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Repo conventions for Claude Code
 
+> **Generic process rules live in `~/.claude/CLAUDE.md`** (auto-loaded by Claude Code from the private [claude-md-global](https://github.com/szhygulin/claude-md-global) repo). The rules below are project-specific.
+
 ## This skill ships zero buildable artifacts
 
 `vaultpilot-security-skill` is **doc-only by design**. Do not add:
@@ -25,34 +27,6 @@ invariants in `SKILL.md`, not by shipping code.
 `SKILL.md` (the agent-side invariants), `README.md`, `CHANGELOG.md`,
 `LICENSE`, `SECURITY.md`, `SKILL-SECURITY.md`. That's the whole shape
 — keep PRs within it.
-
-## Security Incident Response Tone
-- When diagnosing malware/compromise, start with evidence-based scoping before recommending destructive actions (wipe, nuke, rotate-all). Never delete evidence files before reading them.
-
-## Chat Output Formatting
-- Prefer Markdown hyperlinks over raw URLs everywhere: `[label](url)` instead of pasting the full URL inline. This keeps the chat scannable — long URLs (especially swiss-knife decoder URLs with multi-KB calldata query strings, Etherscan tx URLs with hashes, tenderly/phalcon simulation URLs) wrap the terminal into unreadable walls when pasted raw. Apply in user-facing responses AND in any text the server instructs the agent to render (verification blocks, prepare receipts, etc.). Raw URLs are acceptable only when the link is short and already scannable (e.g. a bare domain like `https://ledger.com`) or when explicitly required for machine-readable contexts (e.g. inside a JSON paste-block the user copies into another tool).
-
-## Push-Back Discipline
-- **If the user's request is built on a faulty premise that means the action won't achieve their stated goal, push back BEFORE acting — don't execute and then add a footnote.** Mid-response caveats ("Important caveat: this won't actually fix the thing you asked for") are evidence the wrong action was taken. The right move is to stop, surface the premise mismatch in plain terms, and ask which way to go.
-- Concrete tells that you're about to execute a misguided ask:
-  - Re-running a workflow against a frozen tag/commit/branch that predates the fix the user is trying to apply.
-  - Re-broadcasting a tx with the same nonce when the original was confirmed (would just revert).
-  - Re-querying an API with the same args after a deterministic failure.
-  - Wrapping a destructive action with a comment like "this won't really do what you want, but doing it anyway".
-- Format for push-back: one sentence stating the mismatch + the two or three concrete alternative paths + a question about which to pursue. Keep it short — the goal is to unblock the user's decision, not lecture.
-- If the user explicitly says "do it anyway" after the push-back, proceed. The discipline is about surfacing the issue, not vetoing the user.
-- **Past incident (2026-04-27)**: user asked to retrigger release-binaries.yml against the v0.9.4 tag to recover a missing macos-arm64 binary upload. The tag was frozen at a commit that predated the size + retry fixes (#346 / #349 / #361) just merged into main, so the rerun would have produced the same broken-upload-prone 504MB binary. Caught the issue mid-response but executed the rerun anyway. Right move was to flag the frozen-tag problem first and recommend cutting v0.9.5 (with all fixes baked in) as the alternative.
-
-## Smallest-Solution Discipline
-- **When assessing a GitHub issue or implementing a plan entry, push back with the smallest solution that actually solves the stated problem.** Before writing code, ask: what is the minimum change that makes the failing case pass? Propose that first; only escalate to a heavier design if the minimum demonstrably doesn't cover the requirement. The plan or issue text is a description of the problem, not a license to build infrastructure around it.
-- Concrete tells that the proposed solution is too big:
-  - Caching, indexing, or persisting a dataset to "simulate" or "replay" one operation (e.g. keeping a private blockchain fork in memory to re-run a single transaction; building a request log to replay one API call). One-shot operations don't need persistence layers.
-  - Adding a new module, abstraction, or config surface when an inline change to the existing call site would do.
-  - Introducing a background worker, queue, or scheduler for an action that fires once per user request.
-  - Generalizing for hypothetical future callers when there is exactly one caller today.
-  - "While I'm here" refactors bundled into a fix PR.
-- Format for push-back: one sentence stating the smallest fix you see + one sentence on what the larger proposal adds beyond that + a question on which scope to pursue. If the issue/plan author already specified the heavy approach, surface the lighter alternative explicitly so the user can choose — don't silently downscope either.
-- If the user explicitly says the larger scope is intended, proceed. The discipline is about not defaulting to the heavy option, not vetoing it.
 
 ## Typed-Data Signing Discipline (skill-side)
 - **Invariant #1b (typed-data tree decode) and Invariant #2b (digest recompute) must ship and evolve as a pair.** Never weaken the skill prose to a recompute-only check — a hash recompute over a tampered tree passes tautologically because the digest was computed *over* the swap. The load-bearing layer is #1b's field-level decode + `verifyingContract` pin; #2b is corroborating, in the same way #2 corroborates #1.


### PR DESCRIPTION
## Summary

Removes the project-agnostic process rules from this repo's `CLAUDE.md` — they now live in user-global `~/.claude/CLAUDE.md` (backed by the private [`szhygulin/claude-md-global`](https://github.com/szhygulin/claude-md-global) repo, symlinked at `~/.claude/CLAUDE.md` → `~/.claude-config/CLAUDE.md`, auto-loaded by Claude Code in every project).

**Migrated to global:** Security Incident Response Tone, Chat Output Formatting, Push-Back Discipline, Smallest-Solution Discipline.

**Stays local** (skill-specific):
- Doc-only build/distribution policy ("This skill ships zero buildable artifacts")
- Skill-side Typed-Data Signing Discipline (Inv #1b/#2b lockstep with vaultpilot-mcp tool-surface activation)

File shrinks 63 → 36 lines (43% reduction).

This is one of four parallel migrations across the user's repos (recon-mcp / vaultpilot-security-skill / vaultpilot-smoke-test / vaultpilot-mcp-hosted; transport-skill skipped — its CLAUDE.md only had the no-binaries rule, no generic content to migrate).

## Test plan

- [x] `grep -n '^## '` confirms remaining sections are skill-specific.
- [x] Pointer at top of file names the global location and the backing repo.
- [ ] Verify Claude Code loads `~/.claude/CLAUDE.md` alongside this file in the next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)